### PR TITLE
Fix start-stop-status script (take 2)

### DIFF
--- a/scripts/start-stop-status
+++ b/scripts/start-stop-status
@@ -1,13 +1,25 @@
 #!/bin/bash
 case "$1" in
     start)
-	synosystemctl start pkgctl-homebridge
+        if [ "${EUID}" -eq 0 ]; then
+            sudo -u homebridge synosystemctl start pkguser-homebridge
+        else
+            synosystemctl start pkguser-homebridge
+        fi
         ;;
     stop)
-	synosystemctl stop pkgctl-homebridge
+        if [ "${EUID}" -eq 0 ]; then
+            sudo -u homebridge synosystemctl stop pkguser-homebridge
+        else
+            synosystemctl stop pkguser-homebridge
+        fi
         ;;
     status)
-	synosystemctl get-active-status pkgctl-homebridge
+        if [ "${EUID}" -eq 0 ]; then
+            sudo -u homebridge synosystemctl get-active-status pkguser-homebridge
+        else
+            synosystemctl get-active-status pkguser-homebridge
+        fi
         ;;
     log)
         echo ""
@@ -17,4 +29,3 @@ case "$1" in
         exit 1
         ;;
 esac
-exit 0


### PR DESCRIPTION
Allow the start-stop-status script to be used as root and homebridge.
    
https://github.com/oznu/homebridge-syno-spk/pull/94 broke the script when used as user `homebridge` (which is the case when the service is started using Package Center:
    
```
$ sudo -u homebridge synosystemctl start pkgctl-homebridge
Fail to start [pkgctl-homebridge].
$ sudo -u homebridge synosystemctl start pkguser-homebridge
[pkguser-homebridge] started.
```