### PR TITLE
Add support for RTD1619B (DS124, DS223, DS223j, DS423)

### DIFF
--- a/.ci/build-package.sh
+++ b/.ci/build-package.sh
@@ -7,7 +7,7 @@ set -e
 mkdir -p /toolkit/source
 cp -R $GITHUB_WORKSPACE /toolkit/source/homebridge-syno-spk
 
-# grap the node.js binary
+# grab the node.js binary
 cd /toolkit/source/homebridge-syno-spk
 
 NODE_LTS="$(curl -s https://nodejs.org/dist/index.json | jq -r 'map(select(.lts))[0].version')"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
             * **x86_64** - All 64 bit Intel / AMD CPU Models ( braswell )
             * **evansport** (i686) - DS214play, DS414play, DS415play ( evansport )
             * **rtd1296** (armv8) - DS420j, DS220j, RS819, DS418, DS218, DS218play, DS118
+            * **rtd1619b** (armv8) - DS124, DS223, DS223j, DS423
             * **armada37xx** (armv8) - DS120j, DS119j
             * **armada38x** (armv7) - DS419slim, DS218j, RS217, RS816, DS416j, DS416slim, DS216, DS216j, DS116
             * **alpine** (armv7) - DS1817, DS1517, DS416, DS2015xs, DS1515, DS715, DS215+

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This third-party Synology Package simplifies the process of running [Homebridge]
 * **x86_64** - All 64 bit Intel / AMD CPU Models ( braswell )
 * **evansport** (i686) - DS214play, DS414play, DS415play ( evansport )
 * **rtd1296** (armv8) - DS420j, DS220j, RS819, DS418, DS218, DS218play, DS118
+* **rtd1619b** (armv8) - DS124, DS223, DS223j, DS423
 * **armada37xx** (armv8) - DS120j, DS119j
 * **armada38x** (armv7) - DS419slim, DS218j, RS217, RS816, DS416j, DS416slim, DS216, DS216j, DS116
 * **alpine** (armv7) - DS1817, DS1517, DS416, DS2015xs, DS1515, DS715, DS215+

--- a/repo/index.js
+++ b/repo/index.js
@@ -11,7 +11,7 @@ const path = require('path');
       'kvmx64', 'purley', 'skylaked', 'v1000', 'r1000'],
     evansport: ['i686', 'evansport'],
     alpine: ['armv7', 'alpine', 'alpine4k'],
-    rtd1296: ['armv8', 'rtd1296'],
+    rtd1296: ['armv8', 'rtd1296', 'rtd1619b'],
     armada37xx: ['armada37xx'],
     armada38x: ['armada38x'],
   }


### PR DESCRIPTION
RTD1619B uses the same ARMv8 architecture as its predecessor, RTD1296.